### PR TITLE
feat(seo): add noindex meta tags for amplify domain

### DIFF
--- a/src/components/home/WhyAthletifiSelectSection.tsx
+++ b/src/components/home/WhyAthletifiSelectSection.tsx
@@ -29,7 +29,7 @@ const WhyAthletifiSelectSection = () => {
               className='lg:max-w-[900px] mx-auto'>
               
               <p className='font-Segoe font-normal text-md text-primary opacity-80 text-center mt-4 mb-6'>
-                Building on the incredible success of our 2024 program, AthletiFi Select returns for Summer 2025! Last year, our teams dominated local tournaments with four championship victories at the EDP Summer Sizzler. Join us this summer to be part of our winning tradition!
+                Building on the incredible success of our 2024 program, AthletiFi Select returns for Summer 2025! Last year, our teams dominated local tournaments with four championship victories at the EDP Summer Sizzler and one at the Hershey Summer Classic. Join us this summer to be part of our winning tradition!
               </p>
 
               <h3 className='text-md font-bold mt-6 text-primary'>Program Features:</h3>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,26 +1,43 @@
 // This is the main application file for the Next.js project.
 // It wraps around all pages and can be used to include global styles or components.
-
 import "@/styles/globals.css";
 import AOS from "aos";
 import "aos/dist/aos.css";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { AppProps } from "next/app";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
 import { GoogleAnalytics } from 'nextjs-google-analytics';
-
+import Head from 'next/head';
 
 export default function App({ Component, pageProps }: AppProps) {
-    useEffect(() => {
+  const [isAmplifyDomain, setIsAmplifyDomain] = useState(false);
+
+  useEffect(() => {
+    // Check if we're on the amplifyapp.com domain
+    if (window.location.hostname.includes('amplifyapp.com')) {
+      setIsAmplifyDomain(true);
+    }
+  }, []);
+
+  useEffect(() => {
     setInterval(() => {
       AOS.init({
         once: true,
       });
     }, 1000);
   }, [AOS]);
+
   return (
     <>
+      <Head>
+        {isAmplifyDomain && (
+          <>
+            <meta name="robots" content="noindex,nofollow" />
+            <meta name="googlebot" content="noindex,nofollow" />
+          </>
+        )}
+      </Head>
       <GoogleAnalytics trackPageViews />
       <Component {...pageProps} />
     </>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,12 +1,15 @@
 // This file is used to augment the HTML and body tags of the Next.js application.
 // It's useful for including global CSS or setting meta tags.
-
 import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        {/* This will be overridden by _app.tsx when needed */}
+        <meta name="robots" content="index,follow" />
+        <meta name="googlebot" content="index,follow" />
+      </Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
- Add conditional meta tags in _app.tsx to prevent search indexing on amplifyapp.com
- Update _document.tsx with default index behavior
- Implement dynamic hostname check for meta tag rendering

Resolves Google search duplicate content issue with amplifyapp.com domain